### PR TITLE
Improvements

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { PageProvider } from '@/provider/PageProvider'
 import { SetupPage } from '@/components/pages/setup'
 import { RequirementsProvider } from '@/provider/RequirementsProvider'
 import { ModelDownload } from '@global/types/model'
+import { GlobalProvider } from '@/provider/GlobalProvider'
 
 /**
  * Global window object to expose API methods and data
@@ -42,18 +43,20 @@ declare global {
 export default function App(): ReactElement {
   return (
     <div className="bg-background text-foreground ">
-      <PageProvider>
-        <SidebarProvider>
-          <RequirementsProvider>
-            <SidebarComponent />
-            <main className="flex flex-row w-full">
-              {/* The Setup Page is the initial page */}
-              <SetupPage />
-              <ChatPage />
-            </main>
-          </RequirementsProvider>
-        </SidebarProvider>
-      </PageProvider>
+      <GlobalProvider>
+        <PageProvider>
+          <SidebarProvider defaultOpen>
+            <RequirementsProvider>
+              <SidebarComponent />
+              <main className="flex flex-row w-full">
+                {/* The Setup Page is the initial page */}
+                <SetupPage />
+                <ChatPage />
+              </main>
+            </RequirementsProvider>
+          </SidebarProvider>
+        </PageProvider>
+      </GlobalProvider>
     </div>
   )
 }

--- a/src/renderer/src/components/features/assistant-chat/ChatForm.tsx
+++ b/src/renderer/src/components/features/assistant-chat/ChatForm.tsx
@@ -2,13 +2,14 @@ import { AnimatedLoader } from '@/components/shared/Loader'
 import { ChatInput } from '@/components/ui/chat/chat-input'
 import { ModelFactory } from '@global/factories/model.factory'
 import { Assistant } from '@global/types/assistant'
-import { Button } from '@renderer/components/ui/button'
-import { usePasteOnRightClick } from '@renderer/hooks/use-paste'
-import { SendHorizonal } from 'lucide-react'
-import { ReactElement, useEffect, useRef } from 'react'
 import { ModelStatusCard } from '@renderer/components/features/model-status/ModelStatusCard'
 import { useManageModel } from '@renderer/components/features/model-status/use-manage-model'
+import { Button } from '@renderer/components/ui/button'
+import { usePasteOnRightClick } from '@renderer/hooks/use-paste'
+import { useGlobalContext } from '@renderer/provider/GlobalProvider'
 import { useRequirementsContext } from '@renderer/provider/RequirementsProvider'
+import { SendHorizonal } from 'lucide-react'
+import { ReactElement, useEffect, useRef } from 'react'
 
 interface ChatFormProps {
   assistant: Assistant
@@ -31,6 +32,8 @@ export const ChatForm = ({
   const { isModelInstalled, saveModel } = useManageModel()
   const { isCheckingRequirements } = useRequirementsContext()
 
+  const { setIsSidebarDisabled } = useGlobalContext()
+
   useEffect(() => {
     if (!isLoading) {
       if (inputRef.current) {
@@ -51,6 +54,12 @@ export const ChatForm = ({
         shouldShowCheckButton={false}
         shouldRenderWhenDownloaded={false}
         model={ModelFactory({ name: assistant.model })}
+        onStartedDownloading={() => {
+          setIsSidebarDisabled(true)
+        }}
+        onFinishedDownloading={() => {
+          setIsSidebarDisabled(false)
+        }}
       />
     )
   return (

--- a/src/renderer/src/components/features/assistant-chat/ChatMessage.tsx
+++ b/src/renderer/src/components/features/assistant-chat/ChatMessage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/components/ui/chat/chat-bubble'
 import { AssistantMessage, MessageRole } from '@global/types/assistant'
 import { isCustomRole } from '@global/utils/role.utils'
+import { cn } from '@renderer/lib/utils'
 import { Copy } from 'lucide-react'
 import { ReactElement } from 'react'
 
@@ -48,10 +49,15 @@ export const ChatMessage = ({
     <ChatBubble
       layout={message.role === MessageRole.ASSISTANT ? 'ai' : 'default'}
       variant={getVariant(message.role)}
-      className={`my-2 ${className}`}
+      className={`my-2 ${className} select-text`}
       onClick={() => handleCopy(message.content)}
     >
-      <ChatBubbleAvatar fallback={message.role === MessageRole.ASSISTANT ? 'AI' : 'US'} />
+      <ChatBubbleAvatar
+        className={cn('select-none', {
+          invisible: isLoading
+        })}
+        fallback={message.role === MessageRole.ASSISTANT ? 'AI' : 'US'}
+      />
       <ChatBubbleMessage
         variant={getVariant(message.role)}
         isLoading={showLoadingIcon(isLoading, message)}

--- a/src/renderer/src/components/features/assistant-chat/use-handle-chat.tsx
+++ b/src/renderer/src/components/features/assistant-chat/use-handle-chat.tsx
@@ -5,6 +5,7 @@ import { Page } from '@renderer/pages'
 import { usePageContext } from '@renderer/provider/PageProvider'
 import { FormEvent, useEffect, useState } from 'react'
 import { useManageModel } from '../model-status/use-manage-model'
+import { useGlobalContext } from '@renderer/provider/GlobalProvider'
 
 interface useHandleChatProps {
   history: AssistantHistory | undefined
@@ -25,6 +26,7 @@ interface useHandleChatProps {
 export const useHandleChat = (assistant: Assistant): useHandleChatProps => {
   const { checkRequirementsAreMet } = useManageModel()
   const { setActivePage } = usePageContext()
+  const { setIsSidebarDisabled } = useGlobalContext()
   const [history, setHistory] = useState<AssistantHistory | undefined>(undefined)
   const [textInput, setTextInput] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -154,6 +156,10 @@ export const useHandleChat = (assistant: Assistant): useHandleChatProps => {
     }
     window.api.db.getHistory(assistant.id).then(setHistory)
   }, [assistant])
+
+  useEffect(() => {
+    setIsSidebarDisabled(isLoading)
+  }, [isLoading])
 
   return {
     history,

--- a/src/renderer/src/components/features/model-status/ModelStatusCard.tsx
+++ b/src/renderer/src/components/features/model-status/ModelStatusCard.tsx
@@ -28,7 +28,6 @@ export const ModelStatusCard = ({
 }: ModelStatusCardProps): ReactElement => {
   const [isDownloading, setIsDownloading] = useState(false)
   const [progress, setProgress] = useState(0)
-  const [downloaded, setDownloaded] = useState(false)
 
   const { handleFinishedDownloading } = useManageModel()
 
@@ -37,7 +36,6 @@ export const ModelStatusCard = ({
     if (onStartedDownloading) {
       onStartedDownloading()
     }
-    setDownloaded(false)
     await window.api.ollama.downloadModel(model, (result) => {
       // console.log('Download model result', result)
       if (result.error) {
@@ -49,13 +47,13 @@ export const ModelStatusCard = ({
       if (result.done) {
         // Timeout to debounce the animation
         setTimeout(() => {
-          setDownloaded(true)
           // If shouldRenderWhenDownloaded is set to false, no need to update the ui when finished downloading
           // because the component will be unmounted anyways
+          handleFinishedDownloading(model.name)
+          onFinishedDownloading?.()
           if (!shouldRenderWhenDownloaded) {
             return
           }
-          setIsDownloading(false)
         }, 1000)
       } else {
         setProgress(result.progress)
@@ -70,11 +68,10 @@ export const ModelStatusCard = ({
   }
 
   useEffect(() => {
-    if (downloaded) {
-      handleFinishedDownloading(model.name)
-      onFinishedDownloading?.()
+    if (model.installed) {
+      setIsDownloading(false)
     }
-  }, [downloaded])
+  }, [model.installed])
 
   const renderDownloadingComponent = (): ReactElement => {
     return (

--- a/src/renderer/src/components/features/model-status/ModelStatusCard.tsx
+++ b/src/renderer/src/components/features/model-status/ModelStatusCard.tsx
@@ -6,6 +6,7 @@ import { Progress } from '@renderer/components/ui/progress'
 import { CheckCircle, Circle, Download } from 'lucide-react'
 import { ReactElement, useEffect, useState } from 'react'
 import { useManageModel } from './use-manage-model'
+import { LoadingDots } from '@renderer/components/shared/LoadingDots'
 
 interface ModelStatusCardProps {
   model: ModelDownload
@@ -13,13 +14,17 @@ interface ModelStatusCardProps {
   shouldRenderWhenDownloaded?: boolean
   className?: string
   description?: string
+  onStartedDownloading?: () => void
+  onFinishedDownloading?: () => void
 }
 export const ModelStatusCard = ({
   model,
   shouldShowCheckButton = true,
   shouldRenderWhenDownloaded = true,
   className,
-  description
+  description,
+  onStartedDownloading,
+  onFinishedDownloading
 }: ModelStatusCardProps): ReactElement => {
   const [isDownloading, setIsDownloading] = useState(false)
   const [progress, setProgress] = useState(0)
@@ -29,6 +34,9 @@ export const ModelStatusCard = ({
 
   const downloadModel = async (): Promise<void> => {
     setIsDownloading(true)
+    if (onStartedDownloading) {
+      onStartedDownloading()
+    }
     setDownloaded(false)
     await window.api.ollama.downloadModel(model, (result) => {
       // console.log('Download model result', result)
@@ -41,8 +49,13 @@ export const ModelStatusCard = ({
       if (result.done) {
         // Timeout to debounce the animation
         setTimeout(() => {
-          setIsDownloading(false)
           setDownloaded(true)
+          // If shouldRenderWhenDownloaded is set to false, no need to update the ui when finished downloading
+          // because the component will be unmounted anyways
+          if (!shouldRenderWhenDownloaded) {
+            return
+          }
+          setIsDownloading(false)
         }, 1000)
       } else {
         setProgress(result.progress)
@@ -53,11 +66,13 @@ export const ModelStatusCard = ({
   const cancelDownload = (model: ModelDownload): void => {
     window.api.cancel(DownloadModelEvent + model.name)
     setIsDownloading(false)
+    onFinishedDownloading?.()
   }
 
   useEffect(() => {
     if (downloaded) {
       handleFinishedDownloading(model.name)
+      onFinishedDownloading?.()
     }
   }, [downloaded])
 
@@ -65,7 +80,11 @@ export const ModelStatusCard = ({
     return (
       <div className="space-y-2">
         <div className="flex justify-between text-sm">
-          <span> {progress === 100 ? 'Almost there...' : 'Downloading...'}</span>
+          <span>
+            {' '}
+            {progress === 100 ? 'Almost there' : 'Downloading'}
+            <LoadingDots />
+          </span>
           <span>{Math.round(progress)}%</span>
         </div>
         <div className="flex justify-between items-center gap-3">

--- a/src/renderer/src/components/features/model-status/RequiredModelsComponent.tsx
+++ b/src/renderer/src/components/features/model-status/RequiredModelsComponent.tsx
@@ -29,9 +29,11 @@ export const RequiredModelsComponent = ({ models }: RequiredModelsComponentProps
         <CardDescription>Download the language models you want to use</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {Object.values(models).map((model, index) => (
-          <ModelStatusCard key={model.name + index} model={model} />
-        ))}
+        {Object.values(models)
+          .filter((model) => model.required)
+          .map((model, index) => (
+            <ModelStatusCard key={model.name + index} model={model} />
+          ))}
       </CardContent>
     </Card>
   )

--- a/src/renderer/src/components/features/model-status/use-manage-model.tsx
+++ b/src/renderer/src/components/features/model-status/use-manage-model.tsx
@@ -6,7 +6,7 @@ import requiredModels from '@global/resources/required-models.json'
 interface UseManageModel {
   isModelInstalled: (model: string) => boolean
   handleFinishedDownloading: (model: string) => void
-  syncModelsAndOllamaStatus: (models?: InstalledModels) => Promise<void>
+  syncModelsAndOllamaStatus: (models?: InstalledModels, debounce?: boolean) => Promise<void>
   saveModel: (modelName: string) => Promise<void>
   checkRequirementsAreMet: () => boolean
 }
@@ -52,8 +52,16 @@ export const useManageModel = (): UseManageModel => {
    * the first source can be a model set by the user, then the models from the context, and finally the models from localStorage,
    * if none of these sources have the models, it will create them from the required models json file
    */
-  const syncModelsAndOllamaStatus = async (updatedModels?: InstalledModels): Promise<void> => {
+  const syncModelsAndOllamaStatus = async (
+    updatedModels?: InstalledModels,
+    debounce?: boolean
+  ): Promise<void> => {
     setIsCheckingRequirements(true)
+
+    // the timeout is to debounce the loading animation on the button
+    if (debounce) {
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
 
     let modelsToBeSynced = updatedModels || models || getModelsFromLocalStorage()
 

--- a/src/renderer/src/components/features/setup/OllamaStep.tsx
+++ b/src/renderer/src/components/features/setup/OllamaStep.tsx
@@ -45,7 +45,7 @@ export const OllamaStep = ({
           <CardDescription>
             {ollamaRunning
               ? 'Great! Ollama is installed and ready to use'
-              : 'Ollama needs to be installed to continue'}
+              : 'Ollama needs to be running to continue'}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/renderer/src/components/features/setup/index.tsx
+++ b/src/renderer/src/components/features/setup/index.tsx
@@ -26,7 +26,7 @@ export const SetupComponent = (): ReactElement => {
   } = useHandleSetup()
 
   // The first load when oppening the application
-  if (!hadInitialLoad || isCheckingRequirements || !currentStep) {
+  if (!hadInitialLoad || !currentStep) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center bg-slate-50 dark:bg-secondary text-foreground ">
         <AnimatedLoader />

--- a/src/renderer/src/components/features/setup/use-handle-setup.tsx
+++ b/src/renderer/src/components/features/setup/use-handle-setup.tsx
@@ -74,12 +74,7 @@ export const useHandleSetup = (): UseHandleSetup => {
   }
 
   const refetchRequirementsCheck = async (debounce?: boolean): Promise<void> => {
-    await syncModelsAndOllamaStatus()
-
-    // the timeout is to debounce the loading animation on the button
-    if (debounce) {
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-    }
+    await syncModelsAndOllamaStatus(undefined, debounce)
   }
 
   const openOllamaWebsite = (): void => {

--- a/src/renderer/src/components/shared/LoadingDots.tsx
+++ b/src/renderer/src/components/shared/LoadingDots.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { ReactElement } from 'react'
+
+export const LoadingDots = (): ReactElement => {
+  const [dotIndex, setDotIndex] = useState(0)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDotIndex((prev) => (prev + 1) % 3)
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <>
+      {dotIndex === 0 && '.'}
+      {dotIndex === 1 && '..'}
+      {dotIndex === 2 && '...'}
+    </>
+  )
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,4 +1,5 @@
 import './styles/globals.css'
+import './styles/shared.css'
 
 import { AssistantProvider } from './provider/AssistantProvider'
 

--- a/src/renderer/src/provider/GlobalProvider.tsx
+++ b/src/renderer/src/provider/GlobalProvider.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, ReactElement, ReactNode, useContext, useState } from 'react'
+
+interface GlobalContextType {
+  isSidebarDisabled: boolean
+  setIsSidebarDisabled: (disabled: boolean) => void
+}
+
+const GlobalContext = createContext<GlobalContextType | undefined>(undefined)
+
+export const GlobalProvider = ({ children }: { children: ReactNode }): ReactElement => {
+  const [isSidebarDisabled, setIsSidebarDisabled] = useState(false)
+
+  return (
+    <GlobalContext.Provider
+      value={{
+        isSidebarDisabled,
+        setIsSidebarDisabled
+      }}
+    >
+      {children}
+    </GlobalContext.Provider>
+  )
+}
+
+export const useGlobalContext = (): GlobalContextType => {
+  const context = useContext(GlobalContext)
+  if (!context) {
+    throw new Error('useGlobalContext must be used within a GlobalProvider')
+  }
+  return context
+}

--- a/src/renderer/src/provider/PageProvider.tsx
+++ b/src/renderer/src/provider/PageProvider.tsx
@@ -4,6 +4,8 @@ import { createContext, ReactElement, ReactNode, useContext, useState } from 're
 
 interface PageContextType {
   activePage: string
+  isSidebarDisabled: boolean
+  setIsSidebarDisabled: (disabled: boolean) => void
   setActivePage: (page: string) => void
   withActivePage: (pageName: string, Component: React.ComponentType) => ReactElement
 }
@@ -21,10 +23,14 @@ export const PageProvider = ({ children }: { children: ReactNode }): ReactElemen
     return <></>
   }
 
+  const [isSidebarDisabled, setIsSidebarDisabled] = useState(false)
+
   return (
     <PageContext.Provider
       value={{
         activePage,
+        isSidebarDisabled,
+        setIsSidebarDisabled,
         setActivePage,
         withActivePage
       }}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -6,6 +6,7 @@ html,
 body,
 :root {
   height: 100%;
+  user-select: none;
 }
 
 @layer base {

--- a/src/renderer/src/styles/shared.css
+++ b/src/renderer/src/styles/shared.css
@@ -1,0 +1,4 @@
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,87 +9,87 @@ module.exports = {
   ],
   prefix: '',
   theme: {
-  	container: {
-  		center: true,
-  		padding: '2rem',
-  		screens: {
-  			'2xl': '1400px'
-  		}
-  	},
-  	extend: {
-  		colors: {
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			sidebar: {
-  				DEFAULT: 'hsl(var(--sidebar-background))',
-  				foreground: 'hsl(var(--sidebar-foreground))',
-  				primary: 'hsl(var(--sidebar-primary))',
-  				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-  				accent: 'hsl(var(--sidebar-accent))',
-  				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-  				border: 'hsl(var(--sidebar-border))',
-  				ring: 'hsl(var(--sidebar-ring))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px'
+      }
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
+      keyframes: {
+        'accordion-down': {
+          from: {
+            height: '0'
+          },
+          to: {
+            height: 'var(--radix-accordion-content-height)'
+          }
+        },
+        'accordion-up': {
+          from: {
+            height: 'var(--radix-accordion-content-height)'
+          },
+          to: {
+            height: '0'
+          }
+        }
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out'
+      }
+    }
   },
   plugins: [require('tailwindcss-animate')]
 }


### PR DESCRIPTION
- Add global provider to store shared states (such as disabled sidebar)
- Make sidebar open by default and only toggle it after selecting an assistant if the screen is mobile-sized
- Add loading dots animation when downloading a model
- Solve transition flakiness when finishing downloading a model in the download card
- Disable sidebar when downloading a model or generating a message
- Remove user select and only enable it on specific places (chat messages)
- Hide the AI avatar while the message is still being generated